### PR TITLE
Check the authorization status is "valid" rather than "ready"

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -284,7 +284,7 @@ class Client
             );
             $data = json_decode((string)$response->getBody(), true);
             sleep(1);
-        } while ($maxAttempts < 0 && $data['status'] == 'pending');
+        } while ($maxAttempts > 0 && $data['status'] == 'pending');
 
         return (isset($data['status']) && $data['status'] == 'valid');
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -286,7 +286,7 @@ class Client
             sleep(1);
         } while ($maxAttempts < 0 && $data['status'] == 'pending');
 
-        return (isset($data['status']) && $data['status'] == 'ready');
+        return (isset($data['status']) && $data['status'] == 'valid');
     }
 
     /**


### PR DESCRIPTION
According to [RFC 8555 section 7.1.4](https://tools.ietf.org/html/rfc8555#section-7.1.4) the status of an authorization object can only be "pending", "valid", or "revoked".

An order can have a status of "ready" but never an authorization.