### PR TITLE
Support for DNS validation

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -289,9 +289,9 @@ class Client
             );
             $data = json_decode((string)$response->getBody(), true);
             sleep(1);
-        } while ($maxAttempts < 0 && $data['status'] == 'pending');
+        } while ($maxAttempts > 0 && $data['status'] == 'pending');
 
-        return (isset($data['status']) && $data['status'] == 'ready');
+        return (isset($data['status']) && $data['status'] == 'valid');
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -56,6 +56,11 @@ class Client
     const VALIDATION_HTTP = 'http-01';
 
     /**
+     * DNS validation
+     */
+    const VALIDATION_DNS = 'dns-01';
+
+    /**
      * @var string
      */
     protected $nonce;

--- a/src/Data/Authorization.php
+++ b/src/Data/Authorization.php
@@ -3,6 +3,7 @@
 namespace Afosto\Acme\Data;
 
 use Afosto\Acme\Client;
+use Afosto\Acme\Helper;
 
 class Authorization
 {
@@ -79,6 +80,20 @@ class Authorization
     }
 
     /**
+     * @return Challenge|bool
+     */
+    public function getDnsChallenge()
+    {
+        foreach ($this->getChallenges() as $challenge) {
+            if ($challenge->getType() == Client::VALIDATION_DNS) {
+                return $challenge;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @param Challenge $challenge
      * @return File|bool
      */
@@ -89,5 +104,16 @@ class Authorization
             return $file;
         }
         return false;
+    }
+
+    /**
+     * @param Challenge $challenge
+     * @return string containing TXT record for DNS challenge
+     */
+    public function getTxtRecord(Challenge $challenge)
+    {
+        $raw=$challenge->getToken() . '.' . $this->digest;
+        $hash=hash('sha256', $raw, true);
+        return Helper::toSafeString($hash);
     }
 }

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -135,4 +135,37 @@ class Helper
 
         return $accountDetails;
     }
+
+    /**
+     * Wait until a set of DNS records return specific TXT record values
+     *
+     * @param array mapping domain to desired TXT record value
+     * @param $txtRecord
+     * @param int $maxSeconds to wait
+     * @return bool true if record found, false otherwise
+     */
+    public static function waitForDNS(array $records, $maxSeconds=60)
+    {
+        $waitUntil = time() + $maxSeconds;
+
+        do {
+            //validate all remaining records..
+            foreach($records as $domain=>$txtRecord) {
+                $record=dns_get_record($domain, DNS_TXT);
+                if (isset($record[0]['txt']) && ($record[0]['txt']===$txtRecord)) {
+                    unset($records[$domain]);
+                }
+            }
+
+            //did we find them all?
+            if (empty($records)) {
+                return true;
+            }
+
+            //otherwise still domains to check...have a short sleep
+            sleep(1);
+        } while(time() < $waitUntil);
+
+        return false;
+    }
 }


### PR DESCRIPTION
This adds support for DNS validation, documentation for this has been added to the README. This does not include specific support for any particular DNS provider API, the user must provide that.

Also includes a fix for Client::validate which has an erroneous loop condition and invalid status comparison (also suggested in earlier pull request)