### PR TITLE
Use Flysystem to write certificates instead of plain PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,8 @@ $certificate = $client->getCertificate($order);
 We now have the certificate, to store it on the filesystem:
 ```php
 //Store the certificate and private key where you need it
-file_put_contents('certificate.cert', $certificate->getCertificate());
-file_put_contents('private.key', $certificate->getPrivateKey());
+$filesystem->put('certificates/certificate.cert', $certificate->getCertificate());
+$filesystem->put('certificates/private.key', $certificate->getPrivateKey());
 ```
 
 >To get a seperate intermediate certificate and domain certificate:


### PR DESCRIPTION
While file_put_contents() may get the job done, since you have already suggested using the great FlySystem API, I'd say it would be good to encourage using it in other places as well.