### PR TITLE
Add do.de to the list of users

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,3 +206,4 @@ file_put_contents('private.key', $certificate->getPrivateKey());
 Are you using this package, would love to know. Please send a PR to enlist your project or company. 
 - [Afosto SaaS BV](https://afosto.com)
 - [Web Whales](https://webwhales.nl)
+- [do.de](https://www.do.de)


### PR DESCRIPTION
This adds the german domain hosting company [do.de](https://do.de) as a user of the yaac-library.

Thanks for writing this library, the flysystem-integration and the in-memory handling of certificates and keys are ideal design choices. 