### PR TITLE
Don't sleep when validation succesfull

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -297,7 +297,7 @@ class Client
                 $this->signPayloadKid(null, $challenge->getAuthorizationURL())
             );
             $data = json_decode((string)$response->getBody(), true);
-            if ($maxAttempts > 1) {
+            if ($maxAttempts > 1 && $data['status'] != 'valid') {
                 sleep(ceil(15 / $maxAttempts));
             }
             $maxAttempts--;


### PR DESCRIPTION
Currently the validate function will always sleep, even if the validation was succesfull. Sleeping is only needed when we need to retry.