### PR TITLE
Add ability to generate ECDSA certificate

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -120,6 +120,8 @@ class Client
      * @type string $basePath The base path for the filesystem (used to store account information and csr / keys
      * @type string $username The acme username
      * @type string $source_ip The source IP for Guzzle (via curl.options) to bind to (defaults to 0.0.0.0 [OS default])
+     * @type string $key_type Specifies the type of private key to create (RSA or EC - defaults to EC)
+     * @type string $key_size EC key size, possible values are 256 (prime256v1) or 384 (secp384r1), default is 256
      * }
      */
     public function __construct($config = [])
@@ -315,7 +317,10 @@ class Client
      */
     public function getCertificate(Order $order): Certificate
     {
-        $privateKey = Helper::getNewKey();
+        $privateKey = Helper::getNewKey(
+            $this->getOption('key_type', 'EC'),
+            $this->getOption('key_size', 256)
+        );
         $csr = Helper::getCsr($order->getDomains(), $privateKey);
         $der = Helper::toDer($csr);
 
@@ -498,7 +503,7 @@ class Client
     {
         //Make sure a private key is in place
         if ($this->getFilesystem()->has($this->getPath('account.pem')) === false) {
-            $this->getFilesystem()->write($this->getPath('account.pem'), Helper::getNewKey());
+            $this->getFilesystem()->write($this->getPath('account.pem'), Helper::getNewKey('RSA'));
         }
         $privateKey = $this->getFilesystem()->read($this->getPath('account.pem'));
         $privateKey = openssl_pkey_get_private($privateKey);

--- a/src/Data/Order.php
+++ b/src/Data/Order.php
@@ -121,7 +121,7 @@ class Order
     }
 
     /**
-     * Returs domains as identifiers
+     * Returns domains as identifiers
      * @return array
      */
     public function getIdentifiers(): array


### PR DESCRIPTION
Let'sEncrypt  supports both `RSA` and `ECDSA` certificates. this PR adds ability to generate `ECDSA` certificates too.   
also set the default certificate type to `ECDSA` , so it can be treated as a breaking change