### PR TITLE
Fix return type in Order::getAuthorizationURLs

### DIFF
--- a/src/Data/Order.php
+++ b/src/Data/Order.php
@@ -95,7 +95,7 @@ class Order
 
     /**
      * Return set of authorizations for the order
-     * @return Authorization[]
+     * @return string[]
      */
     public function getAuthorizationURLs(): array
     {


### PR DESCRIPTION
Fix return type in Afosto\Acme\Data\Order::getAuthorizationURLs docblock