### PR TITLE
Allow Data classes to be JSON serialized and unserialized

### DIFF
--- a/src/Data/Account.php
+++ b/src/Data/Account.php
@@ -2,7 +2,7 @@
 
 namespace Afosto\Acme\Data;
 
-class Account
+class Account extends Data
 {
 
     /**
@@ -11,7 +11,7 @@ class Account
     protected $contact;
 
     /**
-     * @var string
+     * @var \DateTime
      */
     protected $createdAt;
 
@@ -105,5 +105,23 @@ class Account
     public function isValid(): bool
     {
         return $this->isValid;
+    }
+
+    /**
+     * @param string $json
+     * @return Account
+     * @throws \Exception
+     */
+    public static function fromJson($json)
+    {
+        $data = json_decode($json, true);
+
+        return new Account(
+            $data['contact'],
+            new \DateTime($data['createdAt']['date']),
+            $data['isValid'],
+            $data['initialIp'],
+            $data['accountURL']
+        );
     }
 }

--- a/src/Data/Authorization.php
+++ b/src/Data/Authorization.php
@@ -5,7 +5,7 @@ namespace Afosto\Acme\Data;
 use Afosto\Acme\Client;
 use Afosto\Acme\Helper;
 
-class Authorization
+class Authorization extends Data
 {
 
     /**
@@ -137,5 +137,24 @@ class Authorization
         }
 
         return false;
+    }
+
+    /**
+     * @param string $json
+     * @return Authorization
+     * @throws \Exception
+     */
+    public static function fromJson($json)
+    {
+        $data = json_decode($json, true);
+
+        $authorization = new Authorization($data['domain'], $data['expires']['date'], $data['digest']);
+
+        // add challenges
+        foreach ($data['challenges'] as $challenge) {
+            $authorization->addChallenge(Challenge::fromJson(json_encode($challenge)));
+        }
+
+        return $authorization;
     }
 }

--- a/src/Data/Certificate.php
+++ b/src/Data/Certificate.php
@@ -4,7 +4,7 @@ namespace Afosto\Acme\Data;
 
 use Afosto\Acme\Helper;
 
-class Certificate
+class Certificate extends Data
 {
 
     /**
@@ -98,5 +98,17 @@ class Certificate
     public function getPrivateKey(): string
     {
         return $this->privateKey;
+    }
+
+    /**
+     * @param string $json
+     * @return Certificate
+     * @throws \Exception
+     */
+    public static function fromJson($json)
+    {
+        $data = json_decode($json, true);
+
+        return new Certificate($data['privateKey'], $data['csr'], $data['chain']);
     }
 }

--- a/src/Data/Challenge.php
+++ b/src/Data/Challenge.php
@@ -2,7 +2,7 @@
 
 namespace Afosto\Acme\Data;
 
-class Challenge
+class Challenge extends Data
 {
 
     /**
@@ -90,5 +90,22 @@ class Challenge
     public function getAuthorizationURL(): string
     {
         return $this->authorizationURL;
+    }
+
+    /**
+     * @param string $json
+     * @return Challenge
+     */
+    public static function fromJson($json)
+    {
+        $data = json_decode($json, true);
+
+        return new Challenge(
+            $data['authorizationURL'],
+            $data['type'],
+            $data['status'],
+            $data['url'],
+            $data['token']
+        );
     }
 }

--- a/src/Data/Data.php
+++ b/src/Data/Data.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Afosto\Acme\Data;
+
+abstract class Data implements DataInterface
+{
+
+    /**
+     * Return data of this class which should be serialized to JSON
+     * More information: https://www.php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return get_object_vars($this);
+    }
+
+    /**
+     * Return JSON string of this class
+     * @return false|string
+     */
+    public function toJson()
+    {
+        return json_encode($this->jsonSerialize());
+    }
+
+    /**
+     * Returns instance of class from JSON string
+     * @param string $json
+     * @return mixed
+     */
+    abstract public static function fromJson($json);
+}

--- a/src/Data/DataInterface.php
+++ b/src/Data/DataInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Afosto\Acme\Data;
+
+interface DataInterface extends \JsonSerializable
+{
+    /**
+     * Return data of this class which should be serialized to JSON
+     * More information: https://www.php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return array
+     */
+    public function jsonSerialize();
+
+    /**
+     * Return JSON string of this class
+     * @return false|string
+     */
+    public function toJson();
+
+    /**
+     * Returns instance of class from JSON string
+     * @param string $json
+     * @return mixed
+     */
+    public static function fromJson($json);
+}

--- a/src/Data/File.php
+++ b/src/Data/File.php
@@ -2,7 +2,7 @@
 
 namespace Afosto\Acme\Data;
 
-class File
+class File extends Data
 {
 
     /**
@@ -42,5 +42,16 @@ class File
     public function getContents(): string
     {
         return $this->contents;
+    }
+
+    /**
+     * @param string $json
+     * @return File
+     */
+    public static function fromJson($json)
+    {
+        $data = json_decode($json, true);
+
+        return new File($data['filename'], $data['contents']);
     }
 }

--- a/src/Data/Order.php
+++ b/src/Data/Order.php
@@ -3,7 +3,7 @@
 
 namespace Afosto\Acme\Data;
 
-class Order
+class Order extends Data
 {
 
     /**
@@ -145,5 +145,25 @@ class Order
     public function getDomains(): array
     {
         return $this->domains;
+    }
+
+    /**
+     * @param string $json
+     * @return Order
+     * @throws \Exception
+     */
+    public static function fromJson($json)
+    {
+        $data = json_decode($json, true);
+
+        return new Order(
+            $data['domains'],
+            $data['url'],
+            $data['status'],
+            $data['expiresAt']['date'],
+            $data['identifiers'],
+            $data['authorizations'],
+            $data['finalizeURL']
+        );
     }
 }

--- a/src/Data/Record.php
+++ b/src/Data/Record.php
@@ -2,7 +2,7 @@
 
 namespace Afosto\Acme\Data;
 
-class Record
+class Record extends Data
 {
 
     /**
@@ -42,5 +42,16 @@ class Record
     public function getValue(): string
     {
         return $this->value;
+    }
+
+    /**
+     * @param string $json
+     * @return Record
+     */
+    public static function fromJson($json)
+    {
+        $data = json_decode($json, true);
+
+        return new Record($data['name'], $data['value']);
     }
 }


### PR DESCRIPTION
Fix #47 

## This pull request introduces...

- [x] JSON serialization and un-serialization of Data classes. 
- [x] A parent class (`Afosto\Acme\Data\Data.php`) for all 'data' classes under the namespace `Afosto\Acme\Data` namespace
  - [x] An interface for `Data` classes (`Afosto\Acme\Data\DataInterface.php`)

## Example use

```php
use Afosto\Acme\Data\Authorization;

// Serialize...

$authorization = new Authorization(...);

$json = $authorization->toJson();
// or
$json = json_encode($authorization);


// Un-serialize...
$authorization = Authorization::fromJson($json);
```

## Testing

The fork used to develop this pull request has been used in a staging area, to generate real LetsEncrypt certificates with success. This fork allows our staging area to run the certificate generation step by step, in different PHP instances.

No breaking changes detected (or expected).

This repo doesn't come with a testing suite and I didn't want to clutter this pull request! 😅

## Use case

It is useful to be able to split an SSL Certificate generation over separate "Jobs" / PHP instances, particularly between running 'self tests' VS real LetsEncrypt tests for authorizations.

This commit allows Data objects to be JSON serialized / unserialized, so the developer can store an unfinished generation and the SSL Certificate generation can easily be picked up by a later PHP process.

This uses PHP's [in-built JSON serialization interface](https://www.php.net/manual/en/class.jsonserializable.php) and extends it to provide the useful helper functions as shown in the examples above..
