### PR TITLE
Chore: Remove param that is not actually passed in

### DIFF
--- a/src/Data/Authorization.php
+++ b/src/Data/Authorization.php
@@ -124,7 +124,6 @@ class Authorization
     /**
      * Returns the DNS record object
      *
-     * @param Challenge $challenge
      * @return Record|bool
      */
     public function getTxtRecord()


### PR DESCRIPTION
Hey @bakkerpeter,

just removing a param that isn't actually passed in the method.

Cheers,
Peter 