### PR TITLE
Added support for retrieving certificates when asynchronous order finalization is enabled on the ACME server-side.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -337,7 +337,7 @@ class Client
         $chain = '';
 
         if (!empty($data['certificate'])) {
-            $chain = $this->getCertficateChain($data['certificate']);
+            $chain = $this->getCertificateChain($data['certificate']);
         } else {
             if ('processing' == $data['status']) {
                 sleep(ceil(15 / $maxAttempts));
@@ -345,7 +345,7 @@ class Client
                     $order = $this->getOrder($order->getId());
 
                     if ('valid' == $order->getStatus()) {
-                        $chain = $this->getCertficateChain($order->getCertificate());
+                        $chain = $this->getCertificateChain($order->getCertificate());
                         break;
                     }
 

--- a/src/Data/Order.php
+++ b/src/Data/Order.php
@@ -37,6 +37,11 @@ class Order
     protected $finalizeURL;
 
     /**
+     * @var string
+     */
+    protected $certificate;
+
+    /**
      * @var array
      */
     protected $domains;
@@ -50,6 +55,7 @@ class Order
      * @param array $identifiers
      * @param array $authorizations
      * @param string $finalizeURL
+     * @param string $certificate
      * @throws \Exception
      */
     public function __construct(
@@ -59,7 +65,8 @@ class Order
         string $expiresAt,
         array $identifiers,
         array $authorizations,
-        string $finalizeURL
+        string $finalizeURL,
+        string $certificate = '',
     ) {
         //Handle the microtime date format
         if (strpos($expiresAt, '.') !== false) {
@@ -72,6 +79,7 @@ class Order
         $this->identifiers = $identifiers;
         $this->authorizations = $authorizations;
         $this->finalizeURL = $finalizeURL;
+        $this->certificate = $certificate;
     }
 
 
@@ -136,6 +144,15 @@ class Order
     public function getFinalizeURL(): string
     {
         return $this->finalizeURL;
+    }
+
+    /**
+     * Returns certificate
+     * @return string
+     */
+    public function getCertificate(): string
+    {
+        return $this->certificate;
     }
 
     /**


### PR DESCRIPTION
### Desc

This fixes issue #63, which is due to the following (partially planned) change at the ACME server implementation level: 
 https://community.letsencrypt.org/t/enabling-asynchronous-order-finalization/193522

### Tests

I've tested it against LE Staging & LE Live successfully.

### Implementation details

The `getCertificate()` method in the `Client` class has been updated to handle cases where the certificate is not immediately available and retries fetching the certificate until it becomes valid.
This also introduces a new (private) method `getCertificateChain()` in the `Client` class, which is used to fetch the certificate chain from the ACME API to avoid implementing the same code multiple times.
Additionally, the `Order` class has been updated to include the new `certificate` property and a corresponding `getCertificate()` getter method.