### PR TITLE
Allow working with LetsEncrypt Pebble and custom base URI

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -290,11 +290,9 @@ class Client
      */
     public function validate(Challenge $challenge, int $maxAttempts = 15): bool
     {
-        $this->request(
+        $response = $this->request(
             $challenge->getUrl(),
-            $this->signPayloadKid([
-                'keyAuthorization' => $challenge->getToken() . '.' . $this->getDigest()
-            ], $challenge->getUrl())
+            $this->signPayloadKid([], $challenge->getUrl())
         );
 
         $data = [];
@@ -753,7 +751,7 @@ class Client
      */
     protected function signPayloadKid($payload, $url): array
     {
-        $payload = is_array($payload) ? str_replace('\\/', '/', json_encode($payload)) : '';
+        $payload = is_array($payload) ? str_replace('\\/', '/', json_encode((object)$payload)) : '';
         $payload = Helper::toSafeString($payload);
         $protected = Helper::toSafeString(json_encode($this->getKID($url)));
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -364,8 +364,15 @@ class Client
 
         $data = json_decode((string)$response->getBody(), true);
         $accountURL = $response->getHeaderLine('Location');
-        $date = (new \DateTime())->setTimestamp(strtotime($data['createdAt']));
-        return new Account($data['contact'], $date, ($data['status'] == 'valid'), $data['initialIp'], $accountURL);
+
+        // Use the current date and time if 'createdAt' is not set
+        $createdAt = $data['createdAt'] ?? (new \DateTime())->format(\DateTime::ATOM);
+        $date = (new \DateTime())->setTimestamp(strtotime($createdAt));
+
+        // Use 'unknown' if 'initialIp' is not set
+        $initialIp = $data['initialIp'] ?? 'unknown';
+
+        return new Account($data['contact'], $date, ($data['status'] == 'valid'), $initialIp, $accountURL);
     }
 
     /**
@@ -487,7 +494,7 @@ class Client
     protected function init()
     {
         //Load the directories from the LE api
-        $response = $this->getHttpClient()->get('/directory');
+        $response = $this->getHttpClient()->get('');
         $result = \GuzzleHttp\json_decode((string)$response->getBody(), true);
         $this->directories = $result;
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -145,16 +145,21 @@ class Client
     }
 
     /**
-     * Get an existing order by ID
+     * Get an existing order by ID or URL
      *
-     * @param $id
+     * @param string $idOrUrl
      * @return Order
      * @throws \Exception
      */
-    public function getOrder($id): Order
+    public function getOrder($idOrUrl): Order
     {
-        $url = str_replace('new-order', 'order', $this->getUrl(self::DIRECTORY_NEW_ORDER));
-        $url = $url . '/' . $this->getAccount()->getId() . '/' . $id;
+        if (strpos($idOrUrl, 'http') === 0) {
+            $url = $idOrUrl;
+        } else {
+            trigger_error("Warning: Constructing URL from ID. This may lead to unexpected behavior if the server uses a different base URL for existing orders.", E_USER_WARNING);
+            $url = str_replace('new-order', 'order', $this->getUrl(self::DIRECTORY_NEW_ORDER));
+            $url = $url . '/' . $this->getAccount()->getId() . '/' . $idOrUrl;
+        }
         $response = $this->request($url, $this->signPayloadKid(null, $url));
         $data = json_decode((string)$response->getBody(), true);
 
@@ -183,7 +188,7 @@ class Client
      */
     public function isReady(Order $order): bool
     {
-        $order = $this->getOrder($order->getId());
+        $order = $this->getOrder($order->getURL());
         return $order->getStatus() == 'ready';
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -116,6 +116,7 @@ class Client
      * @param array $config
      *
      * @type string $mode The mode for ACME (production / staging)
+     * @type string $baseUri The base URI for the ACME API (cannot be supplied when mode is set) 
      * @type Filesystem $fs Filesystem for storage of static data
      * @type string $basePath The base path for the filesystem (used to store account information and csr / keys
      * @type string $username The acme username
@@ -125,6 +126,11 @@ class Client
     public function __construct($config = [])
     {
         $this->config = $config;
+
+        if ($this->getOption('baseUri', false) && $this->getOption('mode', false)) {
+            throw new \LogicException('Both baseUri and mode cannot be supplied simultaneously.');
+        }
+
         if ($this->getOption('fs', false)) {
             $this->filesystem = $this->getOption('fs');
         } else {
@@ -370,9 +376,11 @@ class Client
     {
         if ($this->httpClient === null) {
             $config = [
-                'base_uri' => (
-                ($this->getOption('mode', self::MODE_LIVE) == self::MODE_LIVE) ?
-                    self::DIRECTORY_LIVE : self::DIRECTORY_STAGING),
+                'base_uri' => $this->getOption(
+                    'baseUri',
+                    ($this->getOption('mode', self::MODE_LIVE) == self::MODE_LIVE) ?
+                        self::DIRECTORY_LIVE : self::DIRECTORY_STAGING
+                ),
             ];
             if ($this->getOption('source_ip', false) !== false) {
                 $config['curl.options']['CURLOPT_INTERFACE'] = $this->getOption('source_ip');

--- a/src/Data/Authorization.php
+++ b/src/Data/Authorization.php
@@ -80,6 +80,15 @@ class Authorization
     }
 
     /**
+     * Return this authorization digest
+     * @return string
+     */
+    public function getDigest(): string
+    {
+        return $this->digest;
+    }
+
+    /**
      * Return the HTTP challenge
      * @return Challenge|bool
      */


### PR DESCRIPTION
This pull-request contains minimal code to allow setting custom base URL for a custom directory. That should help testing locally with [Pebble](https://github.com/letsencrypt/pebble) and also possibly use with other ACME servers like @zerossl (https://zerossl.com/documentation/acme/).

It now accepts an option `baseUri` as part of the client initialization, which will override any default URL from LetsEncrypt. That should point to an ACME directory resource. One minor fix had to be made to properly fetch the directory URL pointed by the client, instead of a hardcoded `/directory` one.

One extra detail was that getting the certificate from Pebble required to first trigger the finalize URL to then poll the order for a certificate. I tried to mimic as much as possible the polling code from validate method.

Last but not less, instead of trying to work only with order ID, guessing the base URL, the code had to preserve and reuse the order URL. That's because the order URL from Pebble has not the same prefix than the new-order URL.

