### PR TITLE
FIx for lets encrypt breakage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
   "require": {
     "guzzlehttp/guzzle": "^6.3",
     "league/flysystem": "^1.0",
+    "league/flysystem-local": "^1.0",
     "ext-openssl": "*",
     "ext-json": "*"
   }

--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,8 @@
     }
   },
   "require": {
-    "guzzlehttp/guzzle": "^6.3",
-    "league/flysystem": "^1.0",
-    "league/flysystem-local": "^1.0",
+   "guzzlehttp/guzzle": "^6.3|^7.0",
+    "league/flysystem": "^1.0|^3.0",
     "ext-openssl": "*",
     "ext-json": "*"
   }

--- a/src/Client.php
+++ b/src/Client.php
@@ -357,7 +357,7 @@ class Client
         $data = json_decode((string)$response->getBody(), true);
         $accountURL = $response->getHeaderLine('Location');
         $date = (new \DateTime())->setTimestamp(strtotime($data['createdAt']));
-        return new Account($data['contact'], $date, ($data['status'] == 'valid'), $data['initialIp'], $accountURL);
+        return new Account($data['contact'], $date, ($data['status'] == 'valid'), $accountURL);
     }
 
     /**

--- a/src/Data/Account.php
+++ b/src/Data/Account.php
@@ -43,10 +43,8 @@ class Account
         array $contact,
         \DateTime $createdAt,
         bool $isValid,
-        string $initialIp,
         string $accountURL
     ) {
-        $this->initialIp = $initialIp;
         $this->contact = $contact;
         $this->createdAt = $createdAt;
         $this->isValid = $isValid;


### PR DESCRIPTION
Lets Encrypt changed their output format and removed 'initalIp' from the response which in turn broke the "required" parameter in the Account.php file.

I have removed the requirement for it in both the Account.php and Client.php files