### PR TITLE
initialIP removed from API

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -359,7 +359,7 @@ class Client
         $data = json_decode((string)$response->getBody(), true);
         $accountURL = $response->getHeaderLine('Location');
         $date = (new \DateTime())->setTimestamp(strtotime($data['createdAt']));
-        return new Account($data['contact'], $date, ($data['status'] == 'valid'), $data['initialIp'], $accountURL);
+        return new Account($data['contact'], $date, ($data['status'] == 'valid'), $accountURL);
     }
 
     /**

--- a/src/Data/Account.php
+++ b/src/Data/Account.php
@@ -21,11 +21,6 @@ class Account
     protected $isValid;
 
     /**
-     * @var
-     */
-    protected $initialIp;
-
-    /**
      * @var string
      */
     protected $accountURL;
@@ -36,17 +31,14 @@ class Account
      * @param array $contact
      * @param \DateTime $createdAt
      * @param bool $isValid
-     * @param string $initialIp
      * @param string $accountURL
      */
     public function __construct(
         array $contact,
         \DateTime $createdAt,
         bool $isValid,
-        string $initialIp,
         string $accountURL
     ) {
-        $this->initialIp = $initialIp;
         $this->contact = $contact;
         $this->createdAt = $createdAt;
         $this->isValid = $isValid;
@@ -87,15 +79,6 @@ class Account
     public function getContact(): array
     {
         return $this->contact;
-    }
-
-    /**
-     * Return initial IP
-     * @return string
-     */
-    public function getInitialIp(): string
-    {
-        return $this->initialIp;
     }
 
     /**


### PR DESCRIPTION
The initialIP value has been removed from the Let's Encrypt API, this PR removes it from the Account class to avoid the error.

Ref: https://community.letsencrypt.org/t/has-the-output-of-initialip-changed-in-the-account-directory/229823/3