### PR TITLE
Fix LetsEncrypt breakage following discontinued support for sending expiration notifications

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -359,7 +359,7 @@ class Client
         $data = json_decode((string)$response->getBody(), true);
         $accountURL = $response->getHeaderLine('Location');
         $date = (new \DateTime())->setTimestamp(strtotime($data['createdAt']));
-        return new Account($data['contact'], $date, ($data['status'] == 'valid'), $accountURL);
+        return new Account($date, ($data['status'] == 'valid'), $accountURL);
     }
 
     /**

--- a/src/Data/Account.php
+++ b/src/Data/Account.php
@@ -4,12 +4,6 @@ namespace Afosto\Acme\Data;
 
 class Account
 {
-
-    /**
-     * @var array
-     */
-    protected $contact;
-
     /**
      * @var string
      */
@@ -28,18 +22,15 @@ class Account
 
     /**
      * Account constructor.
-     * @param array $contact
      * @param \DateTime $createdAt
      * @param bool $isValid
      * @param string $accountURL
      */
     public function __construct(
-        array $contact,
         \DateTime $createdAt,
         bool $isValid,
         string $accountURL
     ) {
-        $this->contact = $contact;
         $this->createdAt = $createdAt;
         $this->isValid = $isValid;
         $this->accountURL = $accountURL;
@@ -70,15 +61,6 @@ class Account
     public function getAccountURL(): string
     {
         return $this->accountURL;
-    }
-
-    /**
-     * Return contact data
-     * @return array
-     */
-    public function getContact(): array
-    {
-        return $this->contact;
     }
 
     /**


### PR DESCRIPTION
Let's Encrypt no longer supports sending expiration notifications with contact info. This PR fixes the error.

Ref:
https://letsencrypt.org/2025/01/22/ending-expiration-emails/
https://community.letsencrypt.org/t/support-ended-for-expiration-notification-emails/238173