### PR TITLE
🐛 orders in staging are not immediately available

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -164,7 +164,8 @@ class Client
             $data['expires'],
             $data['identifiers'],
             $data['authorizations'],
-            $data['finalize']
+            $data['finalize'],
+            $data['certificate'] ?? null
         );
     }
 
@@ -216,7 +217,8 @@ class Client
             $data['expires'],
             $data['identifiers'],
             $data['authorizations'],
-            $data['finalize']
+            $data['finalize'],
+            $data['certificate'] ?? null
         );
 
 
@@ -329,9 +331,51 @@ class Client
         );
 
         $data = json_decode((string)$response->getBody(), true);
+
+        $certificateURL = null;
+
+        // normally we'd specify an argument for this but because of the Retry After,
+        // its unlikely to need more than one attempt
+        $maxAttempts = 15;
+
+        if (isset($data['certificate'])) {
+            /**
+             * order is now finalized, certificate was available immediately
+             */
+            $certificateURL = $data['certificate'];
+        } elseif ($data['status'] == 'processing') {
+            /**
+             * order is now finalized, certificate was not created immediately
+             * probably because using staging
+             *
+             * must now wait to get order again until certificate can be retrieved
+             */
+
+            $retryAfter = $response->getHeaderLine('Retry-After');
+            sleep(is_numeric($retryAfter) ? (int) $retryAfter : 1);
+
+            do {
+                $order = $this->getOrder($order->getId());
+
+                if ($order->getStatus() == 'valid') {
+                    $certificateURL = $order->getCertificateURL();
+                    break;
+                }
+
+                $maxAttempts--;
+                sleep(1);
+            } while ($maxAttempts > 0);
+        }
+
+        if ($certificateURL === null) {
+            throw new \RuntimeException(
+                'Certificate download link could not be retrieved. Order was never valid in time.'
+            );
+        }
+
         $certificateResponse = $this->request(
-            $data['certificate'],
-            $this->signPayloadKid(null, $data['certificate'])
+            $certificateURL,
+            $this->signPayloadKid(null, $certificateURL)
         );
         $chain = $str = preg_replace('/^[ \t]*[\r\n]+/m', '', (string)$certificateResponse->getBody());
         return new Certificate($privateKey, $csr, $chain);

--- a/src/Data/Order.php
+++ b/src/Data/Order.php
@@ -42,6 +42,11 @@ class Order
     protected $domains;
 
     /**
+     * @var string|null
+     */
+    protected $certificateURL;
+
+    /**
      * Order constructor.
      * @param array $domains
      * @param string $url
@@ -50,6 +55,7 @@ class Order
      * @param array $identifiers
      * @param array $authorizations
      * @param string $finalizeURL
+     * @param string|null $certificateURL
      * @throws \Exception
      */
     public function __construct(
@@ -59,7 +65,8 @@ class Order
         string $expiresAt,
         array $identifiers,
         array $authorizations,
-        string $finalizeURL
+        string $finalizeURL,
+        $certificateURL
     ) {
         //Handle the microtime date format
         if (strpos($expiresAt, '.') !== false) {
@@ -72,6 +79,7 @@ class Order
         $this->identifiers = $identifiers;
         $this->authorizations = $authorizations;
         $this->finalizeURL = $finalizeURL;
+        $this->certificateURL = $certificateURL;
     }
 
 
@@ -145,5 +153,13 @@ class Order
     public function getDomains(): array
     {
         return $this->domains;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCertificateURL()
+    {
+        return $this->certificateURL;
     }
 }


### PR DESCRIPTION
resolves #63 

I've cross referenced the solutions discussed in that issue, looked at https://github.com/OpenSourceCommerce/acme-client and made note of the Retry After comment and put this together.

I think this is the right solution but I haven't found the API documentation I was looking for so its mostly a guess that the responses from Lets Encrypt mostly fit in to the Order entity in this package.

I'll refactor how `new Order` gets called in the future so this fix is sympathetic to that.